### PR TITLE
VOICEVOXベンチマーク回せるようにした

### DIFF
--- a/lib/VOICEVOXlib.py
+++ b/lib/VOICEVOXlib.py
@@ -144,7 +144,7 @@ class VOICEVOXLib:
         # すべてのURLで失敗した場合
         raise RuntimeError(f"All VOICEVOX URLs failed for synthesis: {text[:50]}...")
 
-    async def synthesize_bytes(self, text, speaker_id) -> bytes:
+    async def synthesize_bytes(self, text, speaker_id) -> tuple[str, bytes]:
         """
         Synthesize speech from text and return audio data as bytes.
 
@@ -153,7 +153,7 @@ class VOICEVOXLib:
             speaker_id (int): The ID of the speaker to use.
 
         Returns:
-            bytes: The synthesized speech audio data.
+            tuple[str, bytes]: The used base URL and the synthesized speech audio data.
         """
         # .envを毎回再読込してURLリストを更新
         self.base_urls = self._load_base_urls()
@@ -198,7 +198,7 @@ class VOICEVOXLib:
                         # 例外は無視して wav_bytes を返す（メトリクスの失敗で処理を止めない）
                         pass
 
-                    return wav_bytes
+                    return base_url, wav_bytes  # 変更: URL とバイトデータをタプルで返す
             except aiohttp.ClientError as e:
                 logging.error(f"VOICEVOX synthesize_bytes failed for URL {base_url}: {e}")
                 continue  # 次のURLを試行


### PR DESCRIPTION
このプルリクエストでは、VOICEVOX 音声合成のベンチマークを行うための新しい管理コマンド「bench」を追加し、VOICEVOX 統合を更新して追加情報を返すようにしました。また、VOICEVOX ライブラリの初期化方法と管理コグへの渡し方もリファクタリングされています。

**管理コマンドの機能強化:**

* `AdminCog` の `admin_command` メソッドに新しい `"bench"` オプションを追加しました。このオプションは、処理時間と音声の長さを測定することで VOICEVOX 音声合成のベンチマークを行い、結果を埋め込み形式で表示します。
* 管理コマンドのヘルプ/エラーメッセージを更新し、新しい `"bench"` オプションを追加しました。

**VOICEVOX 統合の機能強化:**

* `VOICEVOXLib` の `synthesize_bytes` を修正し、バイト数だけでなく、使用した VOICEVOX サーバーの URL と音声バイト数を含むタプルを返すようにしました。
* `AdminCog` とその初期化を更新し、`VOICEVOXLib` インスタンスを受け入れて保存できるようにしました。これにより、適切な依存性注入と使用が保証されます。