### PR TITLE
fix: 自動参加コマンドの説明文を修正

### DIFF
--- a/cogs/voice/basic.py
+++ b/cogs/voice/basic.py
@@ -288,7 +288,7 @@ class VoiceReadCog(commands.Cog):
             )
             await interaction.response.send_message(embed=embed, ephemeral=True)
 
-    @autojoin.command(name="on", description="自動参加を有効にします。現在参加しているVCと読み上げチャンネルをDBに保存します。")
+    @autojoin.command(name="on", description="自動参加を有効にします。設定したいVCに参加している必要があります。")
     async def autojoin_on(self, interaction: discord.Interaction):
         if await self.is_banned(interaction.user.id):
             await interaction.response.send_message("このコマンドを実行する権限がありません。", ephemeral=True)


### PR DESCRIPTION
このプルリクエストは、`cogs/voice/basic.py` ファイル内の `autojoin on` コマンドの説明に若干の更新を加えます。新しい説明では、自動参加を設定するには、ユーザーが既にボイスチャンネルに参加している必要があることが明記されています。