### PR TITLE
fix: タイムアウトを2秒から10秒に延長

### DIFF
--- a/web/app/api/servers/route.ts
+++ b/web/app/api/servers/route.ts
@@ -46,7 +46,7 @@ export async function GET(request: Request) {
   let lastError = null;
   for (let i = 0; i < 1; i++) { // 1回までリトライ（高速化）
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 2000); // 2秒タイムアウト
+    const timeoutId = setTimeout(() => controller.abort(), 10000); // 10秒タイムアウト
     try {
       res = await fetch("https://discord.com/api/v10/users/@me/guilds", {
         headers: {


### PR DESCRIPTION
This pull request makes a small change to the server API route by increasing the timeout duration for a fetch request from 2 seconds to 10 seconds, which should help avoid unnecessary request aborts due to short timeouts.