### PR TITLE
fix: ユーザー情報表示からメールアドレスを削除し、認証スコープを修正

### DIFF
--- a/web/app/dashboard/page.tsx
+++ b/web/app/dashboard/page.tsx
@@ -352,7 +352,6 @@ export default function DashboardPage() {
           >
             <Box sx={{ px: 2, py: 1.5, minWidth: 200 }}>
               <Typography variant="body2" fontWeight={600}>{user?.name ?? "ユーザー"}</Typography>
-              <Typography variant="caption" color="text.secondary">{user?.email}</Typography>
             </Box>
             <Divider />
             <MenuItem onClick={handleSignOut}>サインアウト</MenuItem>
@@ -380,7 +379,7 @@ export default function DashboardPage() {
               </Avatar>
               <Box>
                 <Typography variant="h6" sx={{ fontWeight: 500 }}>
-                  ようこそ、{user?.name ?? user?.email ?? "ゲスト"} さん
+                  ようこそ、{user?.name ?? "ゲスト"} さん
                 </Typography>
                 <Chip label="ログイン済み" size="small" sx={{ mt: 0.5, bgcolor: "#e8f5e9", color: "#2e7d32", fontWeight: 500 }} />
               </Box>

--- a/web/lib/auth.ts
+++ b/web/lib/auth.ts
@@ -6,7 +6,7 @@ export const authOptions = {
       clientId: process.env.DISCORD_CLIENT_ID!,
       clientSecret: process.env.DISCORD_CLIENT_SECRET!,
       // request guilds scope so we can read user's guilds
-      authorization: { params: { scope: "identify email guilds" } },
+      authorization: { params: { scope: "identify guilds" } },
     }),
   ],
   secret: process.env.NEXTAUTH_SECRET,


### PR DESCRIPTION
This pull request primarily updates user privacy and authentication behavior in the dashboard and authentication logic. The most important changes include removing the display of user email in the dashboard UI and adjusting the Discord authentication scope to no longer request the user's email address.

**User privacy improvements:**

* Removed the display of the user's email address from the dashboard UI in `page.tsx`.
* Updated the welcome message to only use the user's name or "ゲスト" (guest), no longer falling back to the email address.

**Authentication scope changes:**

* Changed the Discord OAuth scope in `auth.ts` to exclude the `email` permission, now only requesting `identify` and `guilds` scopes.