### PR TITLE
fix: サーバー数の取得ロジックを修正し、正しいデータフィールドを使用

### DIFF
--- a/web/app/HomeClient.tsx
+++ b/web/app/HomeClient.tsx
@@ -133,8 +133,8 @@ export default function Home() {
     fetch("/api/servercount")
       .then((res) => res.json())
       .then((data) => {
-        if (typeof data.guild_count === "number") {
-          setServerCount(`${data.guild_count}`);
+        if (typeof data.count === "number") {
+          setServerCount(`${data.count}`);
         }
       })
       .catch(() => {


### PR DESCRIPTION
This pull request makes a minor update to the way the server count is handled in the `HomeClient.tsx` component. The code now expects the API response to use the property `count` instead of `guild_count` when updating the server count state.

- Updated the API response property from `guild_count` to `count` in the server count fetch logic in `HomeClient.tsx`