### PR TITLE
feat: サインインページのUIを改善。サーバー数をダッシュボードに表示するように。

### DIFF
--- a/web/app/auth/signin/authclient.tsx
+++ b/web/app/auth/signin/authclient.tsx
@@ -1,51 +1,195 @@
 "use client";
-import { signIn } from "next-auth/react";
+import { useEffect } from "react";
+import { signIn, useSession } from "next-auth/react";
+import { useRouter } from "next/navigation";
 import Box from "@mui/material/Box";
 import Paper from "@mui/material/Paper";
 import Typography from "@mui/material/Typography";
 import Button from "@mui/material/Button";
-import Avatar from "@mui/material/Avatar";
 import Stack from "@mui/material/Stack";
-import { blueGrey } from "@mui/material/colors";
+import Container from "@mui/material/Container";
+import Divider from "@mui/material/Divider";
 import { FaDiscord } from "react-icons/fa";
 
 export default function SignInPage() {
+  const { data: session, status } = useSession();
+  const router = useRouter();
+
+  useEffect(() => {
+    if (status === "authenticated") {
+      // Replace so user can't go back to signin with back button
+      router.replace("/dashboard");
+    }
+  }, [status, router]);
+
+  if (status === "authenticated") {
+    return (
+      <Box
+        sx={{
+          minHeight: "100vh",
+          bgcolor: "#f8f9fa",
+          display: "flex",
+          alignItems: "center",
+          justifyContent: "center",
+          py: 4,
+        }}
+      >
+        <Typography variant="h6" color="text.secondary">
+          リダイレクト中…
+        </Typography>
+      </Box>
+    );
+  }
   return (
-    <Box sx={{ minHeight: "100vh", bgcolor: blueGrey[50], display: "flex", alignItems: "center", justifyContent: "center" }}>
-      <Paper elevation={8} sx={{ p: 5, borderRadius: 4, minWidth: 340, maxWidth: 400, mx: 2 }}>
-        <Stack spacing={3} alignItems="center">
-          <Avatar sx={{ bgcolor: "#5865F2", width: 64, height: 64 }}>
-            <FaDiscord size={38} />
-          </Avatar>
-          <Typography variant="h5" fontWeight={700} color="text.primary">
-            Discordログイン
-          </Typography>
-          <Typography variant="body2" color="text.secondary" align="center">
-            SwiftlyTTSのWeb機能を利用するには、Discordアカウントでログインしてください。
-          </Typography>
-          <Button
-            variant="contained"
-            size="large"
-            startIcon={<FaDiscord size={24} />}
-            sx={{
-              bgcolor: "#5865F2",
-              color: "#fff",
-              fontWeight: 700,
-              borderRadius: 2,
-              textTransform: "none",
-              fontSize: 18,
-              px: 4,
-              py: 1.5,
-              boxShadow: 2,
-              '&:hover': { bgcolor: "#4752C4" },
-              mt: 2,
-            }}
-            onClick={() => signIn("discord", { callbackUrl: `${window.location.origin}/dashboard` })}
-          >
-            Discordでログイン
-          </Button>
-        </Stack>
-      </Paper>
+    <Box
+      sx={{
+        minHeight: "100vh",
+        bgcolor: "#f8f9fa",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        py: 4,
+      }}
+    >
+      <Container maxWidth="sm">
+        <Paper
+          elevation={0}
+          sx={{
+            p: { xs: 4, sm: 6 },
+            borderRadius: 3,
+            border: "1px solid",
+            borderColor: "divider",
+            bgcolor: "#ffffff",
+            maxWidth: 480,
+            mx: "auto",
+            transition: "box-shadow 0.3s ease-in-out",
+            "&:hover": {
+              boxShadow: "0 2px 12px rgba(0,0,0,0.08)",
+            },
+          }}
+        >
+          <Stack spacing={4} alignItems="center">
+            {/* Logo Section */}
+            <Box
+              sx={{
+                width: 80,
+                height: 80,
+                borderRadius: "20px",
+                bgcolor: "#5865F2",
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+                boxShadow: "0 4px 16px rgba(88,101,242,0.24)",
+              }}
+            >
+              <FaDiscord size={44} color="#fff" />
+            </Box>
+
+            {/* Title Section */}
+            <Stack spacing={1} alignItems="center" width="100%">
+              <Typography
+                variant="h4"
+                fontWeight={500}
+                color="text.primary"
+                sx={{
+                  fontSize: { xs: "1.75rem", sm: "2rem" },
+                  letterSpacing: "-0.5px",
+                }}
+              >
+                Swiftly読み上げbot
+              </Typography>
+              <Typography
+                variant="body1"
+                color="text.secondary"
+                align="center"
+                sx={{
+                  fontSize: "1rem",
+                  lineHeight: 1.6,
+                  maxWidth: 360,
+                }}
+              >
+                ダッシュボードにアクセスするには、Discordアカウントでログインしてください
+              </Typography>
+            </Stack>
+
+            <Divider sx={{ width: "100%", my: 2 }} />
+
+            {/* Sign In Button */}
+            <Button
+              variant="outlined"
+              size="large"
+              fullWidth
+              startIcon={<FaDiscord size={24} />}
+              sx={{
+                borderColor: "#dadce0",
+                color: "#3c4043",
+                fontWeight: 600,
+                borderRadius: "8px",
+                textTransform: "none",
+                fontSize: "15px",
+                px: 3,
+                py: 1.75,
+                border: "1.5px solid #dadce0",
+                transition: "all 0.2s ease-in-out",
+                "&:hover": {
+                  bgcolor: "#f8f9fa",
+                  borderColor: "#5865F2",
+                  color: "#5865F2",
+                  boxShadow: "0 1px 4px rgba(0,0,0,0.1)",
+                },
+                "&:active": {
+                  bgcolor: "#e8eaed",
+                },
+                "& .MuiButton-startIcon": {
+                  color: "#5865F2",
+                },
+              }}
+              onClick={() =>
+                signIn("discord", {
+                  callbackUrl: `${window.location.origin}/dashboard`,
+                })
+              }
+            >
+              Discordでログイン
+            </Button>
+
+            {/* Footer Text */}
+            <Typography
+              variant="caption"
+              color="text.secondary"
+              align="center"
+              sx={{
+                fontSize: "0.75rem",
+                lineHeight: 1.5,
+                maxWidth: 340,
+                pt: 2,
+              }}
+            >
+              ログインすることで、SwiftlyTTSの
+              <Box
+                component="a"
+                href="https://github.com/techfish-11/SwiftlyTTS/blob/main/terms-privacy/terms.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{ color: "#5865F2", fontWeight: 600, textDecoration: "underline", mx: 0.5 }}
+              >
+                利用規約
+              </Box>
+              と
+              <Box
+                component="a"
+                href="https://github.com/techfish-11/SwiftlyTTS/blob/main/terms-privacy/privacy.md"
+                target="_blank"
+                rel="noopener noreferrer"
+                sx={{ color: "#5865F2", fontWeight: 600, textDecoration: "underline", mx: 0.5 }}
+              >
+                プライバシーポリシー
+              </Box>
+              に同意したことになります
+            </Typography>
+          </Stack>
+        </Paper>
+      </Container>
     </Box>
   );
 }

--- a/web/app/dashboard/DashboardClient.tsx
+++ b/web/app/dashboard/DashboardClient.tsx
@@ -33,6 +33,9 @@ export default function DashboardClient() {
   const { data: session, status } = useSession();
   const router = useRouter();
 
+  // サーバー数表示用state
+  const [serverCount, setServerCount] = useState<string>("...");
+
   // ユーザー辞書管理用state
   // ギルド辞書管理用state
   const [guilds, setGuilds] = useState<Guild[]>([]);
@@ -149,6 +152,17 @@ export default function DashboardClient() {
     if (status === "authenticated") {
       fetchUserDictionary();
       fetchGuilds();
+      // サーバー数取得
+      fetch("/api/servercount", { credentials: "include" })
+        .then((res) => res.json())
+        .then((data) => {
+          if (typeof data.count === "number") {
+            setServerCount(`${data.count}`);
+          }
+        })
+        .catch(() => {
+          setServerCount("N/A");
+        });
     }
   }, [status, fetchGuilds]);
 
@@ -336,8 +350,24 @@ export default function DashboardClient() {
       <AppBar position="static" elevation={0} sx={{ bgcolor: "white", borderBottom: 1, borderColor: "divider" }}>
         <Toolbar>
           <Typography variant="h6" component="div" sx={{ flexGrow: 1, color: "text.primary", fontWeight: 500 }}>
-            Swiftly TTS
+            Swiftly読み上げbot ダッシュボード
           </Typography>
+          {/* サーバー数表示 */}
+          <Chip
+            label={`${serverCount} サーバー`}
+            size="small"
+            sx={{
+              mr: 2,
+              bgcolor: "#e8f5e9",
+              color: "#2e7d32",
+              fontWeight: 500,
+              fontSize: "0.813rem",
+              height: 28,
+              "& .MuiChip-label": {
+                px: 1.5,
+              },
+            }}
+          />
           <IconButton onClick={handleMenu} sx={{ p: 0 }}>
             <Avatar src={user?.image ?? undefined} alt={user?.name ?? "user"} sx={{ width: 32, height: 32 }}>
               {user?.name ? user.name.charAt(0).toUpperCase() : "U"}

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -17,6 +17,7 @@
         "chart.js": "^4.4.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "framer-motion": "^11.0.0",
         "i18next": "^25.5.2",
         "i18next-browser-languagedetector": "^8.2.0",
         "lucide-react": "^0.541.0",
@@ -5674,13 +5675,13 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.23.12",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.12.tgz",
-      "integrity": "sha512-6e78rdVtnBvlEVgu6eFEAgG9v3wLnYEboM8I5O5EXvfKC8gxGQB8wXJdhkMy10iVcn05jl6CNw7/HTsTCfwcWg==",
+      "version": "11.18.2",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-11.18.2.tgz",
+      "integrity": "sha512-5F5Och7wrvtLVElIpclDT0CBzMVg3dL22B64aZwHtsIY8RB4mXICLrkajK4G9R+ieSAGcgrLeae2SeUTg2pr6w==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.23.12",
-        "motion-utils": "^12.23.6",
+        "motion-dom": "^11.18.1",
+        "motion-utils": "^11.18.1",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -7126,15 +7127,57 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.23.12",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.12.tgz",
-      "integrity": "sha512-RcR4fvMCTESQBD/uKQe49D5RUeDOokkGRmz4ceaJKDBgHYtZtntC/s2vLvY38gqGaytinij/yi3hMcWVcEF5Kw==",
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-11.18.1.tgz",
+      "integrity": "sha512-g76KvA001z+atjfxczdRtw/RXOM3OMSdd1f4DL77qCTF/+avrRJiawSG4yDibEQ215sr9kpinSlX2pCTJ9zbhw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^11.18.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "11.18.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-11.18.1.tgz",
+      "integrity": "sha512-49Kt+HKjtbJKLtgO/LKj9Ld+6vw9BjH5d9sc40R/kVyH8GLAXgT42M2NnuPcJNuA3s9ZfZBUcwIgpmZWGEE+hA==",
+      "license": "MIT"
+    },
+    "node_modules/motion/node_modules/framer-motion": {
+      "version": "12.23.24",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.23.24.tgz",
+      "integrity": "sha512-HMi5HRoRCTou+3fb3h9oTLyJGBxHfW+HnNE25tAXOvVx/IvwMHK0cx7IR4a2ZU6sh3IX1Z+4ts32PcYBOqka8w==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.23.23",
+        "motion-utils": "^12.23.6",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/motion/node_modules/motion-dom": {
+      "version": "12.23.23",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.23.23.tgz",
+      "integrity": "sha512-n5yolOs0TQQBRUFImrRfs/+6X4p3Q4n1dUEqt/H58Vx7OW6RF+foWEgmTVDhIWJIMXOuNNL0apKH2S16en9eiA==",
       "license": "MIT",
       "dependencies": {
         "motion-utils": "^12.23.6"
       }
     },
-    "node_modules/motion-utils": {
+    "node_modules/motion/node_modules/motion-utils": {
       "version": "12.23.6",
       "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.23.6.tgz",
       "integrity": "sha512-eAWoPgr4eFEOFfg2WjIsMoqJTW6Z8MTUCgn/GZ3VRpClWBdnbjryiA3ZSNLyxCTmCQx4RmYX6jX1iWHbenUPNQ==",


### PR DESCRIPTION
このプルリクエストでは、サインインページとダッシュボードページのユーザーインターフェースとユーザーエクスペリエンスにいくつかの改善が加えられ、依存関係の更新も行われています。最も注目すべき変更点は、サインインページの大幅な再設計により、よりモダンな外観と分かりやすいメッセージングが実現したことと、ダッシュボードのヘッダーにサーバー数表示が追加されていることです。また、`framer-motion` 関連の依存関係も更新されています。

**サインインページの再設計と UX の改善:**

* `authclient.tsx` の `SignInPage` は、レイアウトの改善、より明確な説明、利用規約とプライバシーポリシーへの分かりやすいリンクの追加など、よりクリーンでモダンな外観となるよう完全に再設計されました。また、認証済みユーザーはダッシュボードに直接リダイレクトされるようになり、「戻る」ボタンでサインインページに戻らなくなりました。

**ダッシュボードの機能強化:**

* ダッシュボードで、ボットが接続しているサーバーの数を取得して表示するようになりました。サーバー数は、ヘッダーにスタイル付きの `Chip` で表示されます。これには、`serverCount` の新しい状態管理、`/api/servercount` への API 呼び出し、および更新されたヘッダーテキストが含まれます。

**依存関係の更新:**

* `framer-motion` 依存関係が追加され、`package-lock.json` のバージョンが調整されました (v12 から v11 にダウングレード)。また、`motion-dom` および `motion-utils` 依存関係にも対応する変更が加えられ、互換性が確保されました。