### PR TITLE
ダッシュボードの新機能の追加とデフォルトhelpコマンドの無効化

### DIFF
--- a/bot.py
+++ b/bot.py
@@ -35,7 +35,8 @@ intents.message_content = True
 bot = commands.AutoShardedBot(
     command_prefix=config["prefix"],
     shard_count=SHARD_COUNT,  # 環境変数から取得したシャード数を使用
-    intents=intents
+    intents=intents,
+    help_command=None
 )
 bot.config = config  # 追加: 設定をbotインスタンスに保持
     

--- a/lib/bot_http_server.py
+++ b/lib/bot_http_server.py
@@ -124,3 +124,94 @@ async def notify_guild_dictionary(request: Request):
             except Exception as e:
                 print(f"[Notify] guild cache clear error: {e}")
     return {"ok": True}
+
+
+# ボイスサンプル生成（キャッシュ付き）
+_voice_sample_cache = {}  # {speaker_id: wav_bytes}
+
+@app.get("/voice-sample/{speaker_id}")
+async def get_voice_sample(speaker_id: int):
+    """Generate a voice sample for the given speaker_id.
+    
+    Returns cached sample if available, otherwise generates a new one.
+    Sample text: "こんにちは、私の声のサンプルです。"
+    """
+    try:
+        # キャッシュチェック
+        if speaker_id in _voice_sample_cache:
+            print(f"[VoiceSample] Returning cached sample for speaker_id={speaker_id}")
+            from fastapi.responses import Response
+            return Response(
+                content=_voice_sample_cache[speaker_id],
+                media_type="audio/wav",
+                headers={
+                    "Content-Disposition": f"inline; filename=sample_{speaker_id}.wav",
+                    "Cache-Control": "public, max-age=86400"  # 24時間キャッシュ
+                }
+            )
+        
+        # キャッシュになければ生成
+        if _bot is None:
+            raise HTTPException(status_code=503, detail="bot not ready")
+        
+        # VoiceReadCogからVOICEVOXLibを取得
+        cog = _bot.get_cog("VoiceReadCog")
+        if cog is None or not hasattr(cog, "voicelib"):
+            raise HTTPException(status_code=503, detail="VoiceReadCog not available")
+        
+        sample_text = "こんにちは、私の声のサンプルです。"
+        print(f"[VoiceSample] Generating new sample for speaker_id={speaker_id}")
+        
+        # synthesize_bytesを使用してバイトデータを取得
+        _, wav_bytes = await cog.voicelib.synthesize_bytes(sample_text, speaker_id)
+        
+        # キャッシュに保存
+        _voice_sample_cache[speaker_id] = wav_bytes
+        print(f"[VoiceSample] Cached sample for speaker_id={speaker_id}, size={len(wav_bytes)} bytes")
+        
+        from fastapi.responses import Response
+        return Response(
+            content=wav_bytes,
+            media_type="audio/wav",
+            headers={
+                "Content-Disposition": f"inline; filename=sample_{speaker_id}.wav",
+                "Cache-Control": "public, max-age=86400"
+            }
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        print(f"[VoiceSample] Error generating sample for speaker_id={speaker_id}: {e}")
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+# ユーザーボイス変更通知
+@app.post("/user-voice/notify")
+async def notify_user_voice(request: Request):
+    """ユーザーのボイス設定が変更されたときに呼ばれる
+    
+    ユーザー辞書のキャッシュをクリアする（ボイス設定変更時に辞書も再読み込み）
+    """
+    print("[Notify] Received user voice change notification")
+    data = await request.json()
+    user_id = data.get("user_id")
+    print(f"[Notify] user_voice changed for user_id={user_id}")
+    
+    # ユーザー辞書キャッシュをクリア（ボイス変更時に辞書も再適用させる）
+    if _bot is not None and user_id is not None:
+        cog = _bot.get_cog("DictionaryCog")
+        if cog is not None:
+            try:
+                async def clear_cache():
+                    async with cog.cache_lock:
+                        cog.user_dict_cache.pop(int(user_id), None)
+                loop = asyncio.get_event_loop()
+                if loop.is_running():
+                    asyncio.run_coroutine_threadsafe(clear_cache(), loop)
+                else:
+                    loop.run_until_complete(clear_cache())
+                print(f"[Notify] Cleared user dictionary cache for user_id={user_id}")
+            except Exception as e:
+                print(f"[Notify] user voice cache clear error: {e}")
+    
+    return {"ok": True}

--- a/web/app/api/user-voice/route.ts
+++ b/web/app/api/user-voice/route.ts
@@ -1,0 +1,69 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { Pool } from "pg";
+
+// DB接続設定（.envから取得）
+const pool = new Pool({
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT || 5432),
+    user: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_NAME,
+});
+
+// GET: ユーザーの声設定を取得
+export async function GET(req: NextRequest) {
+    const session = await getServerSession(authOptions);
+    if (!session || !session.user?.id) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const userId = session.user.id;
+    const { rows } = await pool.query(
+        "SELECT speaker_id FROM user_voice WHERE user_id = $1",
+        [userId]
+    );
+
+    if (rows.length > 0) {
+        return NextResponse.json({ speaker_id: rows[0].speaker_id });
+    } else {
+        return NextResponse.json({ speaker_id: null });
+    }
+}
+
+// POST: ユーザーの声設定を更新
+export async function POST(req: NextRequest) {
+    const session = await getServerSession(authOptions);
+    if (!session || !session.user?.id) {
+        return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    }
+    const userId = session.user.id;
+    const { speaker_id } = await req.json();
+
+    if (speaker_id === null || speaker_id === undefined) {
+        return NextResponse.json({ error: "Invalid speaker_id" }, { status: 400 });
+    }
+
+    await pool.query(
+        `INSERT INTO user_voice (user_id, speaker_id) VALUES ($1, $2)
+     ON CONFLICT (user_id) DO UPDATE SET speaker_id = $2`,
+        [userId, String(speaker_id)]
+    );
+
+    // ボット側HTTPサーバーに通知（失敗しても無視）
+    try {
+        const botHttpUrl = process.env.BOT_HTTP_URL;
+        if (botHttpUrl) {
+            await fetch(`${botHttpUrl}/user-voice/notify`, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({ user_id: userId }),
+            });
+        }
+    } catch (error) {
+        console.error("Failed to notify bot about voice change:", error);
+        // エラーは無視して続行
+    }
+
+    return NextResponse.json({ ok: true });
+}

--- a/web/app/api/user-voice/route.ts
+++ b/web/app/api/user-voice/route.ts
@@ -44,11 +44,16 @@ export async function POST(req: NextRequest) {
         return NextResponse.json({ error: "Invalid speaker_id" }, { status: 400 });
     }
 
-    await pool.query(
-        `INSERT INTO user_voice (user_id, speaker_id) VALUES ($1, $2)
-     ON CONFLICT (user_id) DO UPDATE SET speaker_id = $2`,
-        [userId, String(speaker_id)]
-    );
+    try {
+        await pool.query(
+            `INSERT INTO user_voice (user_id, speaker_id) VALUES ($1, $2)
+         ON CONFLICT (user_id) DO UPDATE SET speaker_id = $2`,
+            [userId, String(speaker_id)]
+        );
+    } catch (error) {
+        console.error("Database error in user-voice POST:", error);
+        return NextResponse.json({ error: "Database error" }, { status: 500 });
+    }
 
     // ボット側HTTPサーバーに通知（失敗しても無視）
     try {

--- a/web/app/api/voice-sample/[speaker_id]/route.ts
+++ b/web/app/api/voice-sample/[speaker_id]/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest, NextResponse } from "next/server";
+
+// ボット側のHTTP APIからボイスサンプルを取得
+export async function GET(
+    req: NextRequest,
+    { params }: { params: Promise<{ speaker_id: string }> }
+) {
+    const { speaker_id: speakerId } = await params;
+
+    if (!speakerId || isNaN(parseInt(speakerId))) {
+        return NextResponse.json({ error: "Invalid speaker_id" }, { status: 400 });
+    }
+
+    try {
+        const botHttpUrl = process.env.BOT_HTTP_URL;
+        if (!botHttpUrl) {
+            return NextResponse.json({ error: "BOT_HTTP_URL not configured" }, { status: 500 });
+        }
+
+        // ボット側のAPIを呼び出し
+        const response = await fetch(`${botHttpUrl}/voice-sample/${speakerId}`, {
+            method: "GET",
+        });
+
+        if (!response.ok) {
+            throw new Error(`Bot API returned ${response.status}`);
+        }
+
+        // WAVデータを取得
+        const audioBuffer = await response.arrayBuffer();
+
+        // クライアントに返す
+        return new NextResponse(audioBuffer, {
+            status: 200,
+            headers: {
+                "Content-Type": "audio/wav",
+                "Content-Disposition": `inline; filename=sample_${speakerId}.wav`,
+                "Cache-Control": "public, max-age=86400", // 24時間キャッシュ
+            },
+        });
+    } catch (error) {
+        console.error(`Error fetching voice sample for speaker ${speakerId}:`, error);
+        return NextResponse.json(
+            { error: "Failed to fetch voice sample" },
+            { status: 500 }
+        );
+    }
+}

--- a/web/lib/speakers.ts
+++ b/web/lib/speakers.ts
@@ -1,0 +1,41 @@
+// Speaker list from basic.py
+export const SPEAKER_LIST = [
+  { name: "四国めたん", id: 2 },
+  { name: "ずんだもん", id: 3 },
+  { name: "春日部つむぎ", id: 8 },
+  { name: "雨晴はう", id: 10 },
+  { name: "波音リツ", id: 9 },
+  { name: "玄野武宏", id: 11 },
+  { name: "白上虎太郎", id: 12 },
+  { name: "青山龍星", id: 13 },
+  { name: "冥鳴ひまり", id: 14 },
+  { name: "九州そら", id: 16 },
+  { name: "もち子さん", id: 20 },
+  { name: "剣崎雌雄", id: 21 },
+  { name: "WhiteCUL", id: 23 },
+  { name: "後鬼", id: 27 },
+  { name: "No.7", id: 29 },
+  { name: "ちび式じい", id: 42 },
+  { name: "櫻歌ミコ", id: 43 },
+  { name: "小夜/SAYO", id: 46 },
+  { name: "ナースロボ＿タイプＴ", id: 47 },
+  { name: "†聖騎士 紅桜†", id: 51 },
+  { name: "雀松朱司", id: 52 },
+  { name: "麒ヶ島宗麟", id: 53 },
+  { name: "春歌ナナ", id: 54 },
+  { name: "猫使アル", id: 55 },
+  { name: "猫使ビィ", id: 58 },
+  { name: "中国うさぎ", id: 61 },
+  { name: "栗田まろん", id: 67 },
+  { name: "あいえるたん", id: 68 },
+  { name: "満別花丸", id: 69 },
+  { name: "琴詠ニア", id: 74 },
+  { name: "Voidoll", id: 89 },
+  { name: "ぞん子", id: 90 },
+  { name: "中部つるぎ", id: 94 },
+];
+
+export type Speaker = {
+  name: string;
+  id: number;
+};


### PR DESCRIPTION
このプルリクエストにより、ダッシュボードに新しいユーザー音声選択機能が導入され、ユーザーはテキスト読み上げに使用する音声を選択してプレビューできるようになります。ユーザーの音声設定を保存するためのバックエンドサポートが追加され、音声サンプル再生用のAPIが提供され、フロントエンドが更新され、ユーザーが音声サンプルを選択して聞くことができるようになります。変更点には、バックエンドAPIエンドポイント、フロントエンドの状態管理、UIコンポーネント、ボットサーバーとの統合が含まれます。

**ユーザー音声選択とサンプル再生機能:**

* `DashboardClient.tsx` に新しいユーザー音声設定カードが追加されました。これにより、ユーザーは `SPEAKER_LIST` から好みのスピーカーを選択し、各音声のサンプル音声を再生できるようになります。UI は選択内容を更新し、再生エラーを適切に処理します。 [[1]](diffhunk://#diff-0bf442746aa96355e94adf64e4cd2a8acd4fcd02c0017a0870f5eb394aa2a233R55-R60) [[2]](diffhunk://#diff-0bf442746aa96355e94adf64e4cd2a8acd4fcd02c0017a0870f5eb394aa2a233R153-R212) [[3]](diffhunk://#diff-0bf442746aa96355e94adf64e4cd2a8acd4fcd02c0017a0870f5eb394aa2a233R222) [[4]](diffhunk://#diff-0bf442746aa96355e94adf64e4cd2a8acd4fcd02c0017a0870f5eb394aa2a233R665-R719) [[5]](diffhunk://#diff-b44d49df0b45a57739ab0aca0423fac539b1135eb7044c6a2cc6ab1dc82de01bR1-R41)
* ユーザーが選択したスピーカーを取得・更新し、設定をデータベースに保存してボットサーバーに変更を通知するための `/api/user-voice` バックエンドルートを実装しました。
* ボットサーバーから音声サンプルを取得し、適切なヘッダーとキャッシュ情報とともにフロントエンドに返すための `/api/voice-sample/[speaker_id]` ルートを追加しました。([web/app/api/voice-sample/[speaker_id]/route.tsR1-R48](diffhunk://#diff-01a1f183f9a4f6bbc170324f23b41f21730885d3a88a8bc4f0939a14f89df7f8R1-R48))

**ボットサーバー API サポート:**

* `lib/bot_http_server.py` に `/voice-sample/{speaker_id}` エンドポイントを追加しました。これにより、各スピーカーの音声サンプルを生成・キャッシュし、キャッシュヘッダー付きの音声データを返します。
* `lib/bot_http_server.py` に `/user-voice/notify` エンドポイントを追加しました。これにより、ユーザーの音声設定が変更された際に辞書のキャッシュがクリアされ、発音が最新の状態になります。

** 細かな改善:**

* ボットインターフェースをより見やすくするため、`bot.py` のデフォルトのヘルプコマンドを無効化しました。